### PR TITLE
Remove validation of `cordova-plugin-whitelist`

### DIFF
--- a/lib/targets/cordova/target.js
+++ b/lib/targets/cordova/target.js
@@ -47,14 +47,6 @@ module.exports = CoreObject.extend({
   validateServe() {
     let validators = this._buildValidators(true);
 
-    validators.push(
-      new ValidatePlugin({
-        project: this.project,
-        platform: this.platform,
-        pluginName: 'cordova-plugin-whitelist'
-      }).run()
-    );
-
     return runValidators(validators);
   },
 


### PR DESCRIPTION
This prevents live-reload functionality of Android API Level 30 (S+) devices.