### PR TITLE
Allow the user to set the file system watcher

### DIFF
--- a/lib/tasks/bash-serve.js
+++ b/lib/tasks/bash-serve.js
@@ -4,10 +4,11 @@ const Bash             = require('./bash');
 module.exports = Task.extend({
   command: undefined,
   platform: undefined,
+  watcher: undefined,
 
   run() {
     let serve = new Bash({
-      command: `${this.command} --CORBER_PLATFORM=${this.platform}`
+      command: `${this.command} --CORBER_PLATFORM=${this.platform} --watcher=${this.watcher}`
     });
 
     return serve.run();


### PR DESCRIPTION
Cordova allows you to change the file system watch on the live reload command. Adding a way to select it (i.e. `--watcher=polling`) will allow corber to run in docker.